### PR TITLE
Add feature: ability to only pick inbounds meant for specify node

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,16 +1,18 @@
 from decouple import config
 from dotenv import load_dotenv
+import pathlib
 
 load_dotenv()
 
 
-SERVICE_PORT = config('SERVICE_PORT', cast=int, default=62050)
+SERVICE_PORT = config("SERVICE_PORT", cast=int, default=62050)
 
-XRAY_API_PORT = config('XRAY_API_PORT', cast=int, default=62051)
+XRAY_API_PORT = config("XRAY_API_PORT", cast=int, default=62051)
 XRAY_EXECUTABLE_PATH = config("XRAY_EXECUTABLE_PATH", default="/usr/local/bin/xray")
 XRAY_ASSETS_PATH = config("XRAY_ASSETS_PATH", default="/usr/local/share/xray")
 
 SSL_CERT_FILE = config("SSL_CERT_FILE", default="/var/lib/marzban-node/ssl_cert.pem")
 SSL_KEY_FILE = config("SSL_KEY_FILE", default="/var/lib/marzban-node/ssl_key.pem")
+NODE_IP_SAVE_PATH = config("NODE_IP_SAVE_PATH", default="/var/lib/marzban-node/node_ip.txt")
 
 DEBUG = config("DEBUG", cast=bool, default=False)

--- a/domain_resolver.py
+++ b/domain_resolver.py
@@ -1,0 +1,24 @@
+import socket
+import re
+
+
+def _is_domain_test(context):
+    pattern = re.compile("[a-z]")
+    match = pattern.search(context)
+    if match is None:
+        return False
+    else:
+        return True
+
+
+def resolve_domain(domain):
+    is_domain = _is_domain_test(domain)
+    if is_domain is False:
+        return [domain]
+    else:
+        try:
+            result = socket.getaddrinfo(domain, None)
+            ip_addresses_list = [info[4][0] for info in result]
+            return ip_addresses_list
+        except socket.gaierror as e:
+            raise socket.gaierror(f"Error while getting address for ({domain})!! [{e}]")

--- a/node_ip.py
+++ b/node_ip.py
@@ -1,0 +1,75 @@
+import requests
+import random
+
+
+class NodeIP:
+    def __init__(
+        self,
+        logger,
+        force_fake_ip: bool = False,
+        save_path: str = None,
+    ) -> None:
+        self.logger = logger
+        self.force_fake_ip = force_fake_ip
+        self.save_path = save_path
+
+    def _random_num_1_255(self):
+        rand_str = str(random.randint(1, 255))
+        return rand_str
+
+    def _get_ip(self):
+        res = requests.get("https://www.cloudflare.com/cdn-cgi/trace/")
+
+        res_status = res.status_code
+        if res_status == 200:
+            res_text = res.text.splitlines()[2].split("=")[1]
+        else:
+            res_text = None
+
+        return res_text, res_status
+
+    def _save_ip_as_text(self, pre_message: str, ip: str):
+        if self.save_path is None:
+            pass
+        else:
+            with open(f"{self.save_path}/server_ip.txt", "w", encoding="utf-8") as f:
+                f.write(f"{pre_message} {ip}")
+
+    def get_fake_ip(self):
+        random_ip = self._random_num_1_255()
+        for _ in range(3):
+            random_ip += f".{self._random_num_1_255()}"
+
+        self.logger.warning(f"Using a random Fake IP as node ID! ({random_ip})")
+        self.logger.warning(
+            f"This 'Fake IP' will change for every restart of the node script!"
+        )
+        self._save_ip_as_text("Fake IP = ", random_ip)
+        return random_ip
+
+    def get_node_ip(self, maximum_tries: int):
+        if self.force_fake_ip:
+            self.logger.info(f"Forcing Fake IP: Skipping getting node ip !!")
+            return self.get_fake_ip()
+        else:
+            for _ in range(maximum_tries):
+                res = self._get_ip()
+                res_ip = res[0]
+                if res_ip is not None:
+                    self.logger.info(f"Node Ip detected  ({res_ip}).")
+                    self._save_ip_as_text("Real IP = ", res_ip)
+                    return res_ip
+            else:
+                res_status = res[1]
+                self.logger.error(
+                    f"Cloudflare refuses connection for ip detection with status code {res_status} !! "
+                )
+                return self.get_fake_ip()
+
+
+if __name__ == "__main__":
+    from logger import logger
+
+    # a = NodeIP(4, logger, True).get_current_node_ip()
+    a = NodeIP(logger, force_fake_ip=False, save_path=".").get_node_ip(4)
+    print(a)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyOpenSSL==23.0.0
 python-decouple==3.7
 python-dotenv==0.21.1
 rpyc==5.3.0
+requests==2.31.0

--- a/xray.py
+++ b/xray.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from node_ip import NodeIP
 from config import DEBUG, SSL_CERT_FILE, SSL_KEY_FILE, XRAY_API_PORT, NODE_IP_SAVE_PATH
 from logger import logger
+from domain_resolver import resolve_domain
 
 
 class XRayConfig(dict):
@@ -46,8 +47,9 @@ class XRayConfig(dict):
                     f"'node_ips' Must be a 'list' not {type(node_ips_obj)}!"
                 )
             else:
-                for received_ip in node_ips_obj:
-                    if received_ip == current_node_ip:
+                for received_ip_or_domain in node_ips_obj:
+                    ip_list = resolve_domain(received_ip_or_domain)
+                    if current_node_ip in ip_list:
                         # if received_ip was matched : only these inbounds will be placed in xray inbounds
                         current_node_inbounds.append(inbound)
                         break


### PR DESCRIPTION
This is an optional feature which allows admins to specify which inbounds should be used in node Xray.

Benefits : 
- less config to be processed by node Xray.
- listen on less ports when the inbound is not meant to use in node.
- allowing admins to make inbounds configs specific for a node (right now we can but it is not specific).

This is compatible with current Marzban and needs nothing to be done in Master server python codes.

In order to use this future Admin needs to add one key called "node_ip" in inbounds wanted to only be used in node Xray.
like:
```json
"inbounds" : [
      {
          "node_ip": "1.2.3.4",
          // other settings
      }
      // other inbounds
    ]
```
For bellow conditions this future won't be used, and the behavior would be just like before (adding all inbounds to node Xray):
- If "node_ip" was not used in any inbounds.
- If "node_ip" didn't matched the node IP for any inbounds having "node_ip".
